### PR TITLE
feat: implemented phone validation api.

### DIFF
--- a/src/main/java/io/github/kambasdojava/angolaconnectionhub/validations/controller/PhoneValidationController.java
+++ b/src/main/java/io/github/kambasdojava/angolaconnectionhub/validations/controller/PhoneValidationController.java
@@ -1,0 +1,27 @@
+package io.github.kambasdojava.angolaconnectionhub.validations.controller;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.github.kambasdojava.angolaconnectionhub.validations.service.PhoneValidationService;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/validations")
+@RequiredArgsConstructor
+public class PhoneValidationController {
+    private final PhoneValidationService    phoneValidationService;
+
+    @GetMapping("/phone")
+    public ResponseEntity<Object>   validatePhone(@RequestParam String number, @RequestParam List<String> types) {
+        Object  response;
+
+        response = phoneValidationService.validatePhone(number, types);
+        return (ResponseEntity.ok(response));
+    }
+}

--- a/src/main/java/io/github/kambasdojava/angolaconnectionhub/validations/dto/Detail.java
+++ b/src/main/java/io/github/kambasdojava/angolaconnectionhub/validations/dto/Detail.java
@@ -1,0 +1,5 @@
+package io.github.kambasdojava.angolaconnectionhub.validations.dto;
+
+public record Detail(String field, String code, String message)
+{
+}

--- a/src/main/java/io/github/kambasdojava/angolaconnectionhub/validations/dto/PhoneValidationErrorResponse.java
+++ b/src/main/java/io/github/kambasdojava/angolaconnectionhub/validations/dto/PhoneValidationErrorResponse.java
@@ -1,0 +1,13 @@
+package io.github.kambasdojava.angolaconnectionhub.validations.dto;
+
+import java.util.List;
+
+public record PhoneValidationErrorResponse(
+    ErrorDetails error
+) {
+    public record ErrorDetails(
+        String code,
+        String message,
+        List<Detail> details
+    ) {}
+}

--- a/src/main/java/io/github/kambasdojava/angolaconnectionhub/validations/dto/PhoneValidationSuccessResponse.java
+++ b/src/main/java/io/github/kambasdojava/angolaconnectionhub/validations/dto/PhoneValidationSuccessResponse.java
@@ -1,0 +1,7 @@
+package io.github.kambasdojava.angolaconnectionhub.validations.dto;
+
+import java.util.List;
+
+public record PhoneValidationSuccessResponse(boolean success, String message, List<Detail> details)
+{
+}

--- a/src/main/java/io/github/kambasdojava/angolaconnectionhub/validations/service/PhoneValidationService.java
+++ b/src/main/java/io/github/kambasdojava/angolaconnectionhub/validations/service/PhoneValidationService.java
@@ -8,52 +8,48 @@ import java.util.List;
 import java.util.ArrayList;
 
 @Service
-public class PhoneValidationService
-{
+public class PhoneValidationService {
     private static final String regex = "([+]?244)?()?\\d{9}";
 
-    public Object validatePhone(String number, List<String> types)
-    {
+    public Object validatePhone(String number, List<String> types) {
         List<Detail>    details;
 
         details = new ArrayList<>();
         if (types.contains("format") && isInvalidFormat(number, details))
-            return (buildErrorResponse(details));
+            return buildErrorResponse(details);
         if (types.contains("exists") && isNumberUnexistent(number, details))
-            return (buildErrorResponse(details));
+            return buildErrorResponse(details);
         details.add(new Detail("number", "VALID_FORMAT", "O formato do telefone é valido"));
-        return (new PhoneValidationSuccessResponse(true, "Os dados fornecidos são válidos", details));
+        return new PhoneValidationSuccessResponse(true, "Os dados fornecidos são válidos", details);
     }
 
-    private boolean isInvalidFormat(String number, List<Detail> details)
-    {
-        if (!(number.matches(regex))) {
+    private boolean isInvalidFormat(String number, List<Detail> details) {
+        if (!number.matches(regex)) {
             details.add(new Detail("number", "INVALID FORMAT", "O formato do telefone é inválido"));
-            return (true);
+            return true;
         }
-        return (false);
+        return false;
     }
 
-    private boolean isNumberUnexistent(String number, List<Detail> details)
-    {
+    private boolean isNumberUnexistent(String number, List<Detail> details) {
         String          cleanNumber; 
         String          numberPrefix;
 
         if (number.length() < 9) {
             details.add(new Detail("number", "INVALID FORMAT", "O formato do telefone é inválido"));
-            return (true);
+            return true;
         }
         cleanNumber = number.substring(number.length() - 9);
         numberPrefix = cleanNumber.substring(0, 2);
-        if (!(List.of("91", "92", "93", "94", "95", "97", "99").contains(numberPrefix))) {
+        if (!List.of("91", "92", "93", "94", "95", "97", "99").contains(numberPrefix)) {
             details.add(new Detail("number", "NUMBER NOT FOUND", "O número fornecido não existe em nenhuma operadora"));
-            return (true);
+            return true;
         }
-        return (false);
+        return false;
     }
 
     private PhoneValidationErrorResponse buildErrorResponse(List<Detail> details) {
-        return (new PhoneValidationErrorResponse(
-            new PhoneValidationErrorResponse.ErrorDetails("VALIDATION_ERROR", "Os dados fornecidos são inválidos", details)));
+        return new PhoneValidationErrorResponse(
+            new PhoneValidationErrorResponse.ErrorDetails("VALIDATION_ERROR", "Os dados fornecidos são inválidos", details));
     }
 }

--- a/src/main/java/io/github/kambasdojava/angolaconnectionhub/validations/service/PhoneValidationService.java
+++ b/src/main/java/io/github/kambasdojava/angolaconnectionhub/validations/service/PhoneValidationService.java
@@ -1,0 +1,59 @@
+package io.github.kambasdojava.angolaconnectionhub.validations.service;
+
+import io.github.kambasdojava.angolaconnectionhub.validations.dto.PhoneValidationErrorResponse;
+import io.github.kambasdojava.angolaconnectionhub.validations.dto.PhoneValidationSuccessResponse;
+import io.github.kambasdojava.angolaconnectionhub.validations.dto.Detail;
+import org.springframework.stereotype.Service;
+import java.util.List;
+import java.util.ArrayList;
+
+@Service
+public class PhoneValidationService
+{
+    private static final String regex = "([+]?244)?()?\\d{9}";
+
+    public Object validatePhone(String number, List<String> types)
+    {
+        List<Detail>    details;
+
+        details = new ArrayList<>();
+        if (types.contains("format") && isInvalidFormat(number, details))
+            return (buildErrorResponse(details));
+        if (types.contains("exists") && isNumberUnexistent(number, details))
+            return (buildErrorResponse(details));
+        details.add(new Detail("number", "VALID_FORMAT", "O formato do telefone é valido"));
+        return (new PhoneValidationSuccessResponse(true, "Os dados fornecidos são válidos", details));
+    }
+
+    private boolean isInvalidFormat(String number, List<Detail> details)
+    {
+        if (!(number.matches(regex))) {
+            details.add(new Detail("number", "INVALID FORMAT", "O formato do telefone é inválido"));
+            return (true);
+        }
+        return (false);
+    }
+
+    private boolean isNumberUnexistent(String number, List<Detail> details)
+    {
+        String          cleanNumber; 
+        String          numberPrefix;
+
+        if (number.length() < 9) {
+            details.add(new Detail("number", "INVALID FORMAT", "O formato do telefone é inválido"));
+            return (true);
+        }
+        cleanNumber = number.substring(number.length() - 9);
+        numberPrefix = cleanNumber.substring(0, 2);
+        if (!(List.of("91", "92", "93", "94", "95", "97", "99").contains(numberPrefix))) {
+            details.add(new Detail("number", "NUMBER NOT FOUND", "O número fornecido não existe em nenhuma operadora"));
+            return (true);
+        }
+        return (false);
+    }
+
+    private PhoneValidationErrorResponse buildErrorResponse(List<Detail> details) {
+        return (new PhoneValidationErrorResponse(
+            new PhoneValidationErrorResponse.ErrorDetails("VALIDATION_ERROR", "Os dados fornecidos são inválidos", details)));
+    }
+}


### PR DESCRIPTION
## Implementação da Validação de Números de Telefone (Angola)

Este Pull Request responde à Issue de validação de números de telefone para o ecossistema de Angola, implementando uma estrutura robusta, performática e limpa para o `PhoneValidationController` e `PhoneValidationService`.

### O que foi feito:
* **Controller Simplificado:** Criação do endpoint `GET /api/v1/validations/phone` utilizando Lombok (`@RequiredArgsConstructor`) para injeção de dependências limpa, eliminando código boilerplate.
* **Refatoração com Clean Code:** O `PhoneValidationService` foi segmentado em métodos privados especialistas (`isFormatoInvalido`, `isNumeroInexistente`), facilitando a leitura e futuras manutenções.
* **Validação de Operadoras:** Verificação cirúrgica dos prefixos das operadoras nacionais de Angola (Unitel, Movicel, Africell).

---

## Proposta de Melhorias Futuras (Evolução da API)

Durante o desenvolvimento desta Issue, identifiquei duas oportunidades de melhoria arquitetural que gostaria de propor para o repositório, caso faça sentido para a equipa:

### 1. Tratamento Global de Erros com Semântica HTTP (400 Bad Request)
Atualmente, o método devolve os erros de validação dentro de um payload bem estruturado, mas mantém o status HTTP `200 OK`. 
* **Proposta:** No futuro, podemos isolar esta captura utilizando um `@RestControllerAdvice` (Handler Global de Exceções). Sempre que uma validação falhar, disparamos uma exceção customizada (ex: `PhoneValidationException`) e o Spring interceptará para responder com o status **`400 Bad Request`** correto no protocolo HTTP, mantendo o Controller focado apenas no fluxo de sucesso.

### 2. Simplificação do Payload de Sucesso
Para manter o princípio minimalista nas respostas positivas da API, sugiro que nos cenários de sucesso o DTO retorne uma estrutura mais direta, como:
```json
{
  "valid": true,
  "formatted": "923000000",
  "operator": "UNITEL"
}